### PR TITLE
Add Pop and GetOrSet methods to Map

### DIFF
--- a/map.go
+++ b/map.go
@@ -41,6 +41,22 @@ func (m *Map[K, V]) Set(key K, value V) {
 	m.data[key] = value
 }
 
+// GetOrSet returns the existing value for the key if present. Otherwise it sets
+// defaultV for the key and returns it. The boolean return value indicates
+// whether the key was already present.
+// Example:
+//
+//	value, loaded := m.GetOrSet("key", 100)
+func (m *Map[K, V]) GetOrSet(key K, defaultV V) (V, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if value, exists := m.data[key]; exists {
+		return value, true
+	}
+	m.data[key] = defaultV
+	return defaultV, false
+}
+
 // Delete removes the value associated with the key.
 // Example:
 //
@@ -49,6 +65,21 @@ func (m *Map[K, V]) Delete(key K) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.data, key)
+}
+
+// Pop removes the key from the map if it exists and returns the associated value.
+// It returns the value and a boolean indicating whether the key was found.
+// Example:
+//
+//	value, ok := m.Pop("key")
+func (m *Map[K, V]) Pop(key K) (V, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	value, exists := m.data[key]
+	if exists {
+		delete(m.data, key)
+	}
+	return value, exists
 }
 
 // Length returns the number of key-value pairs in the map.

--- a/map_test.go
+++ b/map_test.go
@@ -85,3 +85,40 @@ func TestMapCopy(t *testing.T) {
 		assert.Equal(t, origValue, copyValue)
 	}
 }
+
+func TestMapPop(t *testing.T) {
+	m := NewMap[string, int]()
+	m.Set("key1", 42)
+	value, ok := m.Pop("key1")
+	assert.True(t, ok)
+	assert.Equal(t, 42, value)
+	_, exists := m.Get("key1")
+	assert.False(t, exists)
+}
+
+func TestMapPopNonExistent(t *testing.T) {
+	m := NewMap[string, int]()
+	value, ok := m.Pop("missing")
+	assert.False(t, ok)
+	assert.Equal(t, 0, value)
+}
+
+func TestMapGetOrSetExisting(t *testing.T) {
+	m := NewMap[string, int]()
+	m.Set("key1", 10)
+	value, loaded := m.GetOrSet("key1", 42)
+	assert.True(t, loaded)
+	assert.Equal(t, 10, value)
+	v, _ := m.Get("key1")
+	assert.Equal(t, 10, v)
+}
+
+func TestMapGetOrSetNew(t *testing.T) {
+	m := NewMap[string, int]()
+	value, loaded := m.GetOrSet("key1", 42)
+	assert.False(t, loaded)
+	assert.Equal(t, 42, value)
+	v, ok := m.Get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, 42, v)
+}


### PR DESCRIPTION
## Summary
- add `Pop` and `GetOrSet` methods
- test the new Map APIs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68405b2298b48321bcebe4e886f48ec1